### PR TITLE
Add HTTP server instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,17 @@ npm install
 npm run build
 ```
 
+### Running a local HTTP server
+
+A helper script `start-http.ts` is provided to start the MCP server via HTTP for local testing. After building, run:
+
+```bash
+node start-http.cjs
+```
+
+This starts the server on http://localhost:3000.
+
+
 ## Contributing
 Contributions are welcome! Feel free to submit a Pull Request.
 

--- a/start-http.ts
+++ b/start-http.ts
@@ -5,3 +5,4 @@ createHttpServer({
 }).then(() => {
     console.log('✅ MCP server HTTP listening on port 3000');
 });
+


### PR DESCRIPTION
## Summary
- document running HTTP server with `start-http.ts`
- add newline to `start-http.ts`

## Testing
- `npm run build` *(fails: Cannot find module '@modelcontextprotocol/sdk/server/index.js')*

------
https://chatgpt.com/codex/tasks/task_e_6876a5c2a9108333952ca1b234270618