### PR TITLE
Add HTTP endpoint for Salesforce queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,17 @@ node start-http.cjs
 
 This starts the server on http://localhost:3000.
 
+### Query endpoint
+
+Once the HTTP server is running you can send a POST request to `/query` with the
+SOQL parameters used by the `salesforce_query_records` tool:
+
+```bash
+curl -X POST http://localhost:3000/query \
+  -H "Content-Type: application/json" \
+  -d '{"objectName":"Account","fields":["Id","Name"],"limit":5}'
+```
+
 
 ## Contributing
 Contributions are welcome! Feel free to submit a Pull Request.

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
         "jsforce": "^1.11.1"
     },
     "devDependencies": {
+        "@types/express": "^5.0.3",
         "@types/node": "^22.10.1",
         "shx": "^0.3.4",
         "typescript": "^5.7.2"

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,8 @@ import { MANAGE_OBJECT, handleManageObject, ManageObjectArgs } from "./tools/man
 import { MANAGE_FIELD, handleManageField, ManageFieldArgs } from "./tools/manageField.js";
 import { MANAGE_FIELD_PERMISSIONS, handleManageFieldPermissions, ManageFieldPermissionsArgs } from "./tools/manageFieldPermissions.js";
 import { SEARCH_ALL, handleSearchAll, SearchAllArgs, WithClause } from "./tools/searchAll.js";
+import { createHttpServer } from "./tools/http-server.js";
+import { fileURLToPath } from "url";
 import { READ_APEX, handleReadApex, ReadApexArgs } from "./tools/readApex.js";
 import { WRITE_APEX, handleWriteApex, WriteApexArgs } from "./tools/writeApex.js";
 import { READ_APEX_TRIGGER, handleReadApexTrigger, ReadApexTriggerArgs } from "./tools/readApexTrigger.js";
@@ -341,7 +343,11 @@ async function runServer() {
   console.error("Salesforce MCP Server running on stdio");
 }
 
-runServer().catch((error) => {
-  console.error("Fatal error running server:", error);
-  process.exit(1);
-});
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  runServer().catch((error) => {
+    console.error("Fatal error running server:", error);
+    process.exit(1);
+  });
+}
+
+export { createHttpServer };

--- a/src/tools/http-server.ts
+++ b/src/tools/http-server.ts
@@ -1,0 +1,48 @@
+import express from 'express';
+import { createSalesforceConnection } from '../utils/connection.js';
+import { handleQueryRecords, QueryArgs } from './query.js';
+
+export interface HttpServerOptions {
+  port?: number;
+}
+
+export async function createHttpServer(options: HttpServerOptions = {}) {
+  const port = options.port ?? 3000;
+  const app = express();
+  app.use(express.json());
+
+  app.post('/query', async (req: express.Request, res: express.Response) => {
+    const { objectName, fields, whereClause, orderBy, limit } = req.body;
+
+    if (!objectName || !Array.isArray(fields)) {
+      return res.status(400).json({ error: 'objectName and fields are required' });
+    }
+
+    try {
+      const conn = await createSalesforceConnection();
+      const result = await handleQueryRecords(conn, {
+        objectName,
+        fields,
+        whereClause,
+        orderBy,
+        limit,
+      } as QueryArgs);
+
+      const text = result.content.map((c) => (c.type === 'text' ? c.text : '')).join('\n');
+      if (result.isError) {
+        res.status(400).json({ error: text });
+      } else {
+        res.json({ result: text });
+      }
+    } catch (e) {
+      res.status(500).json({ error: e instanceof Error ? e.message : String(e) });
+    }
+  });
+
+  return new Promise((resolve) => {
+    const server = app.listen(port, () => {
+      console.log(`✅ MCP HTTP server listening on port ${port}`);
+      resolve(server);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add a simple Express HTTP server exposing `/query`
- export `createHttpServer` from main entry
- document new endpoint in README
- add `@types/express` for build

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6877e12dcce88333827aa68db62283f5